### PR TITLE
Add command to set the wait time

### DIFF
--- a/PugLoot.lua
+++ b/PugLoot.lua
@@ -1,3 +1,7 @@
+PUGLOOT_SETTINGS = {
+  wait_time = 15
+}
+
 local roll_state = {}
 local reset_roll_state = function ()
   roll_state.expecting_self_roll = false
@@ -218,7 +222,7 @@ local handle_loot_button = function (kind)
     end
   elseif kind == 'START' then
     if not roll_state.rolling_item then
-      do_start_roll(link, 15)
+      do_start_roll(link, PUGLOOT_SETTINGS.wait_time)
     else
       do_cancel_roll()
     end
@@ -311,7 +315,7 @@ SlashCmdList["PUGLOOT"] = function (arg_str)
     end
   elseif cmd == 'start' and rest then
     if not roll_state.rolling_item then
-      do_start_roll(rest, 15)
+      do_start_roll(rest, PUGLOOT_SETTINGS.wait_time)
     else
       print('There is an ongoing roll for ' .. roll_state.rolling_item)
     end
@@ -321,8 +325,15 @@ SlashCmdList["PUGLOOT"] = function (arg_str)
     else
       print('There is no ongoing roll')
     end
+  elseif cmd == 'set_wait' and rest then
+    PUGLOOT_SETTINGS.wait_time = tonumber(rest)
+    print("Set wait time to " .. PUGLOOT_SETTINGS.wait_time .. " seconds")
   else
-    print('Usage: /pugloot random [item] | /pugloot start [item] | /pugloot cancel')
+    print('Usage:')
+    print('/pugloot random [item]')
+    print('/pugloot start [item]')
+    print('/pugloot cancel')
+    print('/pugloot set_wait [time in seconds]')
   end
 end
 

--- a/PugLoot.toc
+++ b/PugLoot.toc
@@ -2,6 +2,7 @@
 ## Title: PugLoot
 ## Notes: Simple roll accounting and random loot distribution for PUG raids
 ## Author: Urbit (Sulfuras)
-## Version: v1.1.1
+## Version: v1.2.0
+## SavedVariables: PUGLOOT_SETTINGS
 
 PugLoot.lua

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The member with the highest roll is announced along with a summary of all the ro
 Cancel an ongoing roll.  All rolls from the session are discarded.
 
 
+`/pugloot set_wait [time in seconds]`
+
+Sets the amount of time raid members have to roll for each item. defaults to 15 seconds.
+
 ##### Links
 - CurseForge: https://www.curseforge.com/wow/addons/pugloot/
 - GitHub: https://github.com/icheatatlan/PugLoot


### PR DESCRIPTION
This adds a setting for the amount of time given for each roll.  It still defaults to 15 seconds and can be configured using

 /pugloot set_wait [time in seconds]